### PR TITLE
fix scalaVersion mismatches

### DIFF
--- a/stage2/BasicBuild.scala
+++ b/stage2/BasicBuild.scala
@@ -17,10 +17,10 @@ trait BaseBuild extends BuildInterface with DependencyImplementation with SbtDep
   // will create new instances given the context, which means operations in the
   // overrides will happen multiple times and if they are not idempotent stuff likely breaks
   def context: Context
-  lazy val moduleKey: String = "BaseBuild("+target.string+")"
+  lazy val moduleKey: String = "BaseBuild("+scalaTarget.string+")"
   implicit def transientCache: java.util.Map[AnyRef,AnyRef] = context.transientCache
 
-  implicit def libraries(implicit context: Context): libraries = new libraries(context, scalaVersion)
+  def libraries: libraries = new libraries( context, scalaVersion )
 
   // library available to builds
   implicit protected final val logger: Logger = context.logger


### PR DESCRIPTION
- caching key for BasicBuild now takes scalaVersion into account
- cross-rewrite example
  - use outer builds scalaVersion, so that it automatically adapts to it
  - do NOT use outer builds projectdirectory to lookup sources, as it
    changes
  - do make sure projectDirectory exists, to satisfy cbt’s sanity check
  - adapt the scalaVersion of dependencies when they are known unlike
    before where we bound them once forever and later they were wrong